### PR TITLE
Let system decide python executable

### DIFF
--- a/rofi-spotlight.sh
+++ b/rofi-spotlight.sh
@@ -291,10 +291,10 @@ function icon_file_type(){
 }
 
 
-# Pass the argument to python scrupt
+# Pass the argument to python script
 function web_search() {
 	# Pass the search query to web-search script
-	python "${MY_PATH}/web-search.py" "${1}"
+	"${MY_PATH}/web-search.py" "${1}"
 	exit;
 }
 


### PR DESCRIPTION
Problem:
The current way the python script is called does not work on systems where the 'python' binary is still python 2.x

Solution:
The shebang in web-search.py (#!/usr/bin/env python3) is enough to let the system know it is a python script and will automatically use python 3.x if available.